### PR TITLE
Compress Thumbnails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ kamadak-exif = "^0.5"
 lazy_static = "1.4.0"
 open = "2.0.2"
 parking_lot = "^0.12"
+qoi = "^0.4"
 rayon = "1.5.0"
 rfd = "^0.8"
 rusqlite = { version="^0.27", features=["bundled", "time", "functions", "serde_json"] } # bundled uses bundled version for Windows.  blob feature might be needed for io.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ PixelBox is still pre-alpha.  Database schema and feature prioritization are sub
 * Torch for training the image similarity model
 * ONNX for running the similarity model
 
-### TODOs
-* Compress thumbnails in database
-* Index inside of zip files
+### TODOs for Alpha Release
+* ~~Compress thumbnails in database~~ [DONE 2022/04/30 - 2x Compression for No Loss in Speed]
 * Remove from index on folder clear
-* Better similarity search
 * Start removing those unwraps
+* Settings Page
+ 
+### TODOs for Roadmap
+* Index inside of zip files
+* Better similarity search
 * OCR for images (search on text in images)
 * Editable tags
 * Face search

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ pub struct MainApp {
 	// Start Tab:
 	
 	// Search Tab:
+	thumbnail_size: (u32, u32),
 	search_text: String,
 	query_error: String,
 	some_value: f32,
@@ -56,7 +57,8 @@ impl Default for MainApp {
 			engine: None,
 			active_tab: AppTab::Start,
 			image_id_to_texture_handle: HashMap::new(),
-			
+
+			thumbnail_size: (128, 128),
 			search_text: "".to_string(),
 			query_error: "".to_string(),
 			some_value: 1.0f32,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -33,14 +33,15 @@ fn load_image_from_memory(image_data: &[u8]) -> Result<ColorImage, image::ImageE
 }
 
 fn indexed_image_to_egui_colorimage(indexed_image: &IndexedImage, alpha_fill:u8) -> ColorImage {
-	let num_pixels = indexed_image.thumbnail_resolution.0 * indexed_image.thumbnail_resolution.1;
+	let (thumbnail_data, thumbnail_resolution) = indexed_image.get_thumbnail();
+	let num_pixels = thumbnail_resolution.0 * thumbnail_resolution.1;
 	let mut new_vec = Vec::with_capacity((num_pixels / 3 * 4) as usize);
-	indexed_image.thumbnail.chunks(3).for_each(|p|{
+	thumbnail_data.chunks(3).for_each(|p|{
 		new_vec.extend(p);
 		new_vec.push(alpha_fill);
 	});
 	ColorImage::from_rgba_unmultiplied(
-		[indexed_image.thumbnail_resolution.0 as usize, indexed_image.thumbnail_resolution.1 as usize],
+		[thumbnail_resolution.0 as usize, thumbnail_resolution.1 as usize],
 		new_vec.as_slice()
 	)
 }

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -61,7 +61,8 @@ pub fn search_panel(
 						ui.horizontal(|ui|{
 							let tex_id = fetch_or_generate_thumbnail(res, &mut app_state.image_id_to_texture_handle, ui.ctx());
 
-							ui.image(&tex_id, [res.thumbnail_resolution.0 as f32, res.thumbnail_resolution.1 as f32]).context_menu(|ui|{
+							// Note: thumbnail size != image size.  We might want to show them off as larger or smaller.
+							ui.image(&tex_id, [app_state.thumbnail_size.0 as f32, app_state.thumbnail_size.1 as f32]).context_menu(|ui|{
 								if ui.button("Open").clicked() {
 									//let _ = std::process::Command::new("open").arg(&res.path).output();
 									open::that(&res.path);


### PR DESCRIPTION
Image Thumbnails are currently stored as raw bytes (u8 RGB) in the database with separate info for width and height.
Since it's unlikely people will want to manipulate the thumbnails in an outside application, let's compress them to cut down on storage costs.

Before DB Index of Test Directory: 3954976KB

After DB Index of Test Directory: 1991480KB

50.3% space reduction!  No visible runtime increase because the compression overhead of QOI was offset by the write speed bump.