### PR TITLE
First swing at ZipFile support. (Issue #16)

### DIFF
--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -1,9 +1,14 @@
-
+use anyhow::{Result, anyhow};
 use crossbeam::channel::{Receiver, Sender, unbounded};
 use glob::glob;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::{BufReader, BufRead, Read};
 use std::path::PathBuf;
 
 use crate::indexed_image::{IndexedImage, stringify_filepath};
+
+const SUPPORTED_IMAGE_EXTENSIONS: &'static [&str; 12] = &["png", "bmp", "jpg", "jpeg", "jfif", "gif", "tiff", "pnm", "webp", "ico", "tga", "exr"];
 
 /// Given a vec of directory globs and a set of valid extensions,
 /// crawl the disk and index images.
@@ -29,7 +34,7 @@ pub fn crawl_globs_async(globs:Vec<String>, parallel_file_loaders:usize) -> (Rec
 					match maybe_fname {
 						Ok(path) => {
 							println!("Checking {}", stringify_filepath(&path));
-							if path.is_file() && is_supported_extension(&path) {
+							if path.is_file() {
 								if let Err(e) = tx.send(path) {
 									eprintln!("Failed to submit image for processing: {}", e);
 								}
@@ -48,31 +53,67 @@ pub fn crawl_globs_async(globs:Vec<String>, parallel_file_loaders:usize) -> (Rec
 		let rx = file_rx.clone();
 		let tx = image_tx.clone();
 		std::thread::spawn(move || {
-			while let Ok(image_path) = rx.recv() {
-				// Calculate the bare minimum that needs calculating and insert it.
-				match IndexedImage::from_file_path(&image_path.as_path()) {
-					Ok(img) => {
-						tx.send(img);
-					},
-					Err(e) => {
-						println!("Error processing {}: {}", image_path.display(), e);
+			while let Ok(file_path) = rx.recv() {
+				// File path is any generic file, not necessarily an image file.
+				// We need to check if it's an image, a zip file, or something else.
+				if let Some(extension) = file_path.extension().and_then(OsStr::to_str) {
+					// Figure out the kind of file.
+					let is_zipfile = extension.eq_ignore_ascii_case("zip");
+					let mut is_image_file = false;
+
+					if !is_zipfile { // Save ourselves some compute by skipping the extension check for zipfiles.
+						for &ext in SUPPORTED_IMAGE_EXTENSIONS {
+							if extension.eq_ignore_ascii_case(ext) {
+								is_image_file = true;
+							}
+						}
 					}
-				}
+
+					// Send one or more images to the image_tx queue.
+					if is_zipfile {
+						// Iterate over the zip files by index.  Maybe we could do name, but that seems to require a seek.
+						if let Ok(fin) = File::open(&file_path) {
+							let mut bufreader = BufReader::new(fin);
+							if let Ok(mut zipfile) = zip::ZipArchive::new(bufreader) {
+								let filenames = zipfile.file_names().map(String::from).collect::<Vec<String>>();
+								for filename in &filenames {
+									// Try to pull and check the extension:
+									if let Ok(mut compressed_file) = zipfile.by_name(filename) {
+										if !compressed_file.is_file() { continue; }
+
+										let mut valid_image = false;
+										for &ext in SUPPORTED_IMAGE_EXTENSIONS {
+											if filename.ends_with(ext) {
+												valid_image = true;
+												break;
+											}
+										}
+										if !valid_image { continue; }
+
+										let mut data:Vec<u8> = vec![];
+										compressed_file.read(&mut data);
+
+										if let Ok(img) = IndexedImage::from_memory(&mut data, filename.to_string(), format!("{}/{}", &file_path.display(), filename)) {
+											tx.send(img);
+										}
+									}
+								}
+							}
+						}
+					} else if is_image_file {
+						match IndexedImage::from_file_path(&file_path.as_path()) {
+							Ok(img) => {
+								tx.send(img);
+							},
+							Err(e) => {
+								println!("Error processing {}: {}", file_path.display(), e);
+							}
+						}
+					}
+				} // Else we have to skip it.  No extension.
 			}
 		});
 	}
 
 	(file_rx, image_rx)
-}
-
-fn is_supported_extension(path:&PathBuf) -> bool {
-	if let Some(extension) = path.extension().and_then(|s| s.to_str()) {
-		let ext = extension.to_lowercase();
-		for &supported_extension in &["png", "bmp", "jpg", "jpeg", "jfif", "gif", "tiff", "pnm", "webp", "ico", "tga", "exr"] {
-			if ext == supported_extension {
-				return true;
-			}
-		}
-	}
-	return false;
 }

--- a/src/indexed_image.rs
+++ b/src/indexed_image.rs
@@ -18,8 +18,9 @@ pub const THUMBNAIL_SIZE: (u32, u32) = (256, 256);
 #[derive(Clone, Debug)]
 pub struct IndexedImage {
 	pub id: i64,
-	pub filename: String,
+	pub filename: String, // This is for display and search, not for actually opening the file.
 	pub path: String,
+	pub container_path: String, // "" by default, but if the image is inside of a zipfile, this will be the path to the zipfile.
 	pub resolution: (u32, u32),
 	pub thumbnail: Vec<u8>,
 	pub created: Instant,
@@ -77,6 +78,7 @@ impl IndexedImage {
 				id: 0,
 				filename: filename,
 				path: path,
+				container_path: "".to_owned(),
 				resolution: (img.width(), img.height()),
 				thumbnail: qoi_thumb,
 				created: Instant::now(),


### PR DESCRIPTION
These changes are a little messy.  I think the IndexedImage file needs a better way to read from an in-memory image.  The handling of zipfiles is also not great, and I think when we start monitoring for on-disk changes it's going to get worse.  Perhaps the crawler's ingesting methods could be split off into a separate file.

WIP for https://github.com/JosephCatrambone/pixelbox/issues/16