### PR TITLE
Separate out the crawler from the search.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ image = "0.25.9"
 kamadak-exif = "0.6.1"
 lazy_static = "1.5.0"
 open = "5.3.3"
-parking_lot = "0.12.5"
 qoi = "0.4.1"
 #rayon = "1.11.0"
 rfd = "0.15.4"
-rusqlite = { version="0.37.0", features=["bundled", "time", "functions", "serde_json"] } # bundled uses bundled version for Windows.  blob feature might be needed for io.
+rusqlite = { version="0.38.0", features=["bundled", "time", "functions", "serde_json"] } # bundled uses bundled version for Windows.  blob feature might be needed for io.
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = "1.0.145"
 tract-onnx = "0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ lazy_static = "1.5.0"
 open = "5.3.3"
 qoi = "0.4.1"
 #rayon = "1.11.0"
-rfd = "0.15.4"
-rusqlite = { version="0.38.0", features=["bundled", "time", "functions", "serde_json"] } # bundled uses bundled version for Windows.  blob feature might be needed for io.
+rfd = "0.17.2"
+rusqlite = { version="0.38.0", features=["bundled", "functions", "hooks", "serde_json"] } # bundled uses bundled version for Windows.  blob feature might be needed for io.
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = "1.0.145"
 tract-onnx = "0.22.0"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ PixelBox is still pre-alpha.  Database schema and feature prioritization are sub
 * models - The final ONNX files to be used by the application for visual similarity
 * resources - Non-shipped experiment logs and python training files
 * src - The main application code
-  * image_hashes - Wrappers for different image hashing methods
+  * image_hashes - Wrappers for different image hashing methods.
   * ui - Code for each of the major UI panels like search view, folder view, etc.
+  * engine.rs - Main database interface for search and store.
+  * crawler.rs - Folder indexing and background loading work.
 
 ### Using Your Own Image Hash (Advanced)
 

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -1,15 +1,11 @@
 use anyhow::{Result, anyhow};
-use crossbeam::channel::{Receiver, Sender, unbounded};
+use crossbeam::channel::{Receiver, bounded, unbounded, TryRecvError, TrySendError};
 use glob::glob;
 use std::ffi::OsStr;
-use std::fs::File;
-use std::io::{BufReader, BufRead, Read};
-use std::path::PathBuf;
-
 use crate::indexed_image::{IndexedImage, stringify_filepath};
 
 const SUPPORTED_IMAGE_EXTENSIONS: &'static [&str; 12] = &["png", "bmp", "jpg", "jpeg", "jfif", "gif", "tiff", "pnm", "webp", "ico", "tga", "exr"];
-
+const MAX_PENDING_TX: usize = 128;
 
 #[derive(Default)]
 pub struct Crawler {
@@ -23,17 +19,21 @@ impl Crawler {
 		}
 	}
 
-	pub fn start_indexing(&mut self, folders: Vec<String>) -> Receiver<IndexedImage> {
-		let (image_tx, image_rx) = unbounded();
+	pub fn start_indexing(
+			&mut self,
+			folders: Vec<String>,
+			num_workers: usize,
+	) -> Receiver<IndexedImage> {
+		let (filename_tx, filename_rx) = unbounded();
+		let (image_tx, image_rx) = bounded(MAX_PENDING_TX);
 
 		let res = image_rx;
 
 		{
 			let globs = folders.clone();
-			let tx = image_tx.clone();
 
 			std::thread::spawn(move || {
-				'end: for mut g in globs {
+				for mut g in globs {
 					g.push(std::path::MAIN_SEPARATOR);
 					g.push_str("**");
 					g.push(std::path::MAIN_SEPARATOR);
@@ -52,21 +52,7 @@ impl Crawler {
 										}
 
 										if is_image_file {
-											match IndexedImage::from_file_path(&path.as_path()) {
-												Ok(img) => {
-													let e = tx.send(img);
-													if e.is_err() {
-														// Close our connection.
-														break 'end;
-													}
-													println!("... processed!");
-												},
-												Err(e) => {
-													println!("Error processing {}: {}", path.display(), e);
-												}
-											}
-										} else {
-											println!("... skipped");
+											filename_tx.send(path).expect("Can't send file path to image processing thread. This should never happen.");
 										}
 									} // Else we have to skip it.  No extension.
 								}
@@ -75,7 +61,60 @@ impl Crawler {
 						}
 					}
 				}
+				drop(filename_tx);
+			});
+		}
+
+		for _ in 0..num_workers {
+			let rx = filename_rx.clone();
+			let tx = image_tx.clone();
+			std::thread::spawn(move || {
+				let mut send_buffer = Vec::new();
+				let mut file_stream_open = true;
+				'end: loop {
+					if file_stream_open { // We might be able to avoid this check and just hit rx err every time.
+						match rx.try_recv() {
+							Ok(path) => {
+								if let Ok(img) = IndexedImage::from_file_path(&path.as_path()) {
+									send_buffer.push(img); // Build up buffer in the thread so we don't have as much IPC overhead.
+								}
+							},
+							Err(TryRecvError::Empty) => {
+								// Just wait.  Maybe sleep?
+							},
+							Err(TryRecvError::Disconnected) => {
+								file_stream_open = false;
+							}
+						}
+					}
+
+					// Push the images back to the original thread.
+					// If the image stream is closed, we can abort.
+					if tx.is_full() { continue; }
+					if let Some(img) = send_buffer.pop() {
+						match tx.try_send(img.clone()) {
+							Ok(_) => {},
+							Err(TrySendError::Disconnected(_)) => {
+								// Main thread can't get anything.
+								return;
+							},
+							Err(TrySendError::Full(_)) => {
+								// It's full.  Push back onto buffer.
+								send_buffer.push(img);
+								std::thread::yield_now();
+							}
+						}
+					} else {
+						std::thread::yield_now();
+					}
+
+					// Small chance that we just can't list file fast enough?
+					if !file_stream_open && send_buffer.is_empty() {
+						break 'end;
+					}
+				}
 				drop(tx);
+				println!("Image processing thread quitting. No work left.");
 			});
 		}
 

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -10,6 +10,29 @@ use crate::indexed_image::{IndexedImage, stringify_filepath};
 
 const SUPPORTED_IMAGE_EXTENSIONS: &'static [&str; 12] = &["png", "bmp", "jpg", "jpeg", "jfif", "gif", "tiff", "pnm", "webp", "ico", "tga", "exr"];
 
+
+#[derive(Default)]
+pub struct Crawler {
+	tracked_folders: Vec<String>,
+	on_filename_crawled: Vec<Box<dyn Fn(&String)>>,
+	on_image_processed: Vec<Box<dyn Fn(IndexedImage)>>,
+	on_image_processing_failure: Vec<Box<dyn Fn(&String, &String)>>,
+}
+
+impl Crawler {
+	pub fn new() -> Self {
+		Crawler::default()
+	}
+	
+	pub fn add_tracked_folder(&mut self, folder: String) {
+		
+	}
+	
+	pub fn rescan_index(&mut self, force: bool) {
+		
+	}
+}
+
 /// Given a vec of directory globs and a set of valid extensions,
 /// crawl the disk and index images.
 /// Returns a Channel with Images as they're created.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -115,9 +115,11 @@ impl Engine {
 	pub fn open(filename:&Path) -> Self {
 		let mut conn = Connection::open(filename).expect("Unable to open filename.");
 
-		make_hamming_distance_db_function(&mut conn);
-		make_byte_distance_db_function(&mut conn);
-		make_cosine_distance_db_function(&mut conn);
+		conn.pragma_update(None, "journal_mode", "WAL").expect("Unable to set write-ahead logging.");
+
+		make_hamming_distance_db_function(&mut conn).expect("Could not initialize hamming distance function in DB.");
+		make_byte_distance_db_function(&mut conn).expect("Could not initialize byte distance function in DB.");
+		make_cosine_distance_db_function(&mut conn).expect("Could not initialize cosine distance function in DB.");
 
 		Engine {
 			connection: Arc::new(Mutex::new(conn)),
@@ -479,7 +481,7 @@ fn tokenize_query(query: &String) -> Result<Vec<String>> {
 	Ok(spans)
 }
 
-fn build_where_clause_from_parsed_query(tokens: &Vec<String>, mut cached_similar_image: &mut Option<IndexedImage>) -> String {
+fn build_where_clause_from_parsed_query(tokens: &Vec<String>, cached_similar_image: &mut Option<IndexedImage>) -> String {
 	// If there's a magic prefix like "similar", "filename", or a tag, add that to a 'where'.
 	// Otherwise, search all of the tags and exif data.
 

--- a/src/image_hashes/mod.rs
+++ b/src/image_hashes/mod.rs
@@ -1,6 +1,7 @@
 
 mod efficientnet;
 mod phash;
+mod nomic;
 
 pub use phash::phash;
 pub use efficientnet::mlhash;

--- a/src/image_hashes/nomic.rs
+++ b/src/image_hashes/nomic.rs
@@ -1,0 +1,63 @@
+use std::sync::LazyLock;
+use image::{DynamicImage, GenericImageView, imageops::FilterType};
+use tract_onnx::prelude::*;
+
+const SIMILARITY_MODEL_PATH:&'static str = "models/nomic_embed_vision_v1_5_int8.onnx";
+const MODEL_INPUT_WIDTH:u32 = 224;
+const MODEL_INPUT_HEIGHT:u32 = 224;
+const MODEL_LATENT_SIZE:usize = 197*768;
+
+
+static MODEL: LazyLock<RunnableModel<TypedFact, Box<dyn TypedOp>, Graph<TypedFact, Box<dyn TypedOp>>>> = LazyLock::new(|| {
+	tract_onnx::onnx().model_for_path(SIMILARITY_MODEL_PATH).expect("Unable to load similarity model from disk!").into_optimized().unwrap().into_runnable().unwrap()
+});
+
+
+fn image_to_tensor(img: &DynamicImage) -> Tensor {
+	let img = img.resize_to_fill(MODEL_INPUT_WIDTH, MODEL_INPUT_HEIGHT, FilterType::Triangle).to_rgb8();
+	let data: Tensor = tract_ndarray::Array4::from_shape_fn((1, 3, 224, 224), |(_, c, y, x)| {
+		let mean = 0.0;
+		let std = 1.0;
+		(img[(x as _, y as _)][c] as f32 / 255.0 - mean) / std
+	}).into();
+	data
+}
+
+pub fn mlhash(img:&DynamicImage) -> Vec<u8> {
+	//let model = tract_onnx::onnx().model_for_path(SIMILARITY_MODEL_PATH).expect("Unable to load similarity model from disk!").into_optimized().unwrap().into_runnable().unwrap();
+	let img_tensor = image_to_tensor(img);
+	let output = MODEL.run(tvec!(img_tensor.into())).expect("Failed to generate embedding for image. This should never happen.");
+	let float_embed = output[0]
+		.to_array_view::<f32>()
+		.unwrap()
+		.iter()
+		.map(|f| { 128u8.saturating_add_signed((f*128.0f32).max(-128.0f32).min(128.0f32) as i8) })
+		.collect::<Vec<u8>>();
+	float_embed
+}
+
+#[cfg(test)]
+mod test {
+	use std::env;
+	use std::path::Path;
+	use crate::engine::hamming_distance;
+	use super::mlhash;
+
+	const SRC_FILE: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/", file!());
+	const TEST_IMAGE_DIRECTORY: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/", "test_resources");
+
+	#[test]
+	fn test_sanity() {
+		println!("CWD: {:?}", &env::current_dir().unwrap());
+		println!("Loading images from {:}", TEST_IMAGE_DIRECTORY);
+
+		let mut diff = 0f32;
+		let img = image::open(Path::new(TEST_IMAGE_DIRECTORY).join("phash_test_a.png")).unwrap();
+		let img_hash = mlhash(&img);
+
+		// Cases that should match:
+		diff = hamming_distance(&img_hash, &img_hash);
+		assert_eq!(diff, 0f32);
+		//assert!(hamming_distance(&flat_hash, &img_rot_hash) > 0.5);
+	}
+}

--- a/src/indexed_image.rs
+++ b/src/indexed_image.rs
@@ -26,7 +26,7 @@ pub struct IndexedImage {
 	pub tags: HashMap<String, String>,
 
 	pub phash: Option<Vec<u8>>,
-	pub visual_hash: Option<Vec<u8>>, // For visual-similarity, like style and structure.  Not for content.
+	pub visual_hash: Option<Vec<u8>>, // An embedding of the image.
 	//pub content_hash: Option<Vec<u8>>, //
 
 	pub distance_from_query: Option<f64>,
@@ -51,7 +51,7 @@ impl IndexedImage {
 		//let mut img = image::open(path)?;
 		//let mut img:DynamicImage = image::load_from_memory(bytes)?;
 		//let mut img:DynamicImage = image::load_from_memory_with_format(bytes.as_slice(), ImageFormat::from_path(&path)?)?;
-		let mut img:DynamicImage = image::io::Reader::new(&mut cursor).with_guessed_format()?.decode()?;
+		let img:DynamicImage = image::ImageReader::new(&mut cursor).with_guessed_format()?.decode()?;
 		let thumb = img.thumbnail(THUMBNAIL_SIZE.0, THUMBNAIL_SIZE.1).to_rgb8();
 		let thumbnail_width = thumb.width();
 		let thumbnail_height = thumb.height();
@@ -67,8 +67,9 @@ impl IndexedImage {
 			}
 		}
 
-		// And generate a perceptual hash.
-		let hash = Some(mlhash(&img));
+		// Generate hashes
+		let phash = phash(&img);
+		let visual_hash = mlhash(&img);
 
 		Ok(
 			IndexedImage {
@@ -82,8 +83,8 @@ impl IndexedImage {
 
 				tags: tags,
 
-				phash: Some(phash(&img)),  // Disable for a little while to check performance.
-				visual_hash: hash,
+				phash: Some(phash),
+				visual_hash: Some(visual_hash),
 
 				distance_from_query: None,
 			}

--- a/src/indexed_image.rs
+++ b/src/indexed_image.rs
@@ -14,6 +14,13 @@ use crate::image_hashes::mlhash;
 pub const THUMBNAIL_SIZE: (u32, u32) = (256, 256);
 
 #[derive(Clone, Debug)]
+pub struct UnindexedImage {
+	pub filename: String,
+	pub path: String,
+	pub resolution: (u32, u32),
+}
+
+#[derive(Clone, Debug)]
 pub struct IndexedImage {
 	pub id: i64,
 	pub filename: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ impl Default for MainApp {
 			image_id_to_texture_handle: HashMap::new(),
 
 			thumbnail_size: 128,
-			search_text_min_length: 2,
+			search_text_min_length: 0,
 			search_text: "".to_string(),
 			query_error: "".to_string(),
 			some_value: 1.0f32,
@@ -101,7 +101,7 @@ impl eframe::App for MainApp {
 }
 
 
-fn main() {
+fn main() -> Result<(), eframe::Error> {
 	let app = MainApp::default();
 	let options = eframe::NativeOptions {
 		..Default::default()
@@ -111,6 +111,6 @@ fn main() {
 	eframe::run_native("PixelBox", options, Box::new(|ctx| {
 		egui_extras::install_image_loaders(&ctx.egui_ctx);
 		Ok(Box::<MainApp>::new(app))
-	}));
+	}))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ mod image_hashes;
 mod indexed_image;
 mod ui;
 
+use crate::engine::Engine;
 use crate::indexed_image::{IndexedImage, THUMBNAIL_SIZE};
 use eframe::{egui, self, NativeOptions};
-use engine::Engine;
 use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
@@ -90,11 +90,11 @@ impl eframe::App for MainApp {
 				(None, _) => ui::start::start_panel(ui),
 				(_, AppTab::Start) => ui::start::start_panel(ui),
 				// If the engine is loaded...
-				(Some(_), AppTab::Search) => ui::search::search_panel(self, ui),
+				(Some(_engine), AppTab::Search) => ui::search::search_panel(self, ui),
 				(Some(engine), AppTab::Folders) => ui::folders::folder_panel(engine, ctx, ui),
-				(Some(_), AppTab::View) => ui::view::view_panel(self, ui),
-				(Some(_), AppTab::Settings) => ui::settings::settings_panel(self, ui),
-				(Some(_), _) => ()
+				(_, AppTab::View) => ui::view::view_panel(self, ui),
+				(_, AppTab::Settings) => ui::settings::settings_panel(self, ui),
+				// (_, _) => ()
 			}
 		});
 	}

--- a/src/ui/folders.rs
+++ b/src/ui/folders.rs
@@ -50,7 +50,7 @@ pub fn folder_panel(
 				engine.get_num_indexed_images();
 				ui.label(format!("Reindexing.  Progress: {}%", 100.0*engine.get_indexing_progress()));
 				//ui.vertical_centered(|ui| {});
-				for file in engine.get_last_indexed() {
+				for file in engine.get_last_added() {
 					ui.label(file);
 				}
 			} else {

--- a/src/ui/folders.rs
+++ b/src/ui/folders.rs
@@ -49,6 +49,9 @@ pub fn folder_panel(
 			// Show Reindexing Button
 			if engine.is_indexing_active() {
 				ui.label(format!("Reindexing.  {} images indexed", engine.get_num_indexed_images()));
+				if ui.button("Stop Indexing").clicked() {
+					engine.stop_indexing();
+				}
 				//ui.vertical_centered(|ui| {});
 				for file in engine.get_last_added() {
 					ui.label(file);

--- a/src/ui/folders.rs
+++ b/src/ui/folders.rs
@@ -5,6 +5,7 @@ use rfd;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use crate::crawler::Crawler;
 
 pub fn folder_panel(
 		engine: &mut Engine,
@@ -47,15 +48,14 @@ pub fn folder_panel(
 		.show(ctx, |ui| {
 			// Show Reindexing Button
 			if engine.is_indexing_active() {
-				engine.get_num_indexed_images();
-				ui.label(format!("Reindexing.  Progress: {}%", 100.0*engine.get_indexing_progress()));
+				ui.label(format!("Reindexing.  {} images indexed", engine.get_num_indexed_images()));
 				//ui.vertical_centered(|ui| {});
 				for file in engine.get_last_added() {
 					ui.label(file);
 				}
 			} else {
 				if ui.button("Reindex").clicked() {
-					engine.start_reindexing();
+					engine.start_indexing();
 				}
 			}
 		});

--- a/src/ui/search.rs
+++ b/src/ui/search.rs
@@ -2,7 +2,7 @@ use crate::{AppTab, MainApp};
 //use crate::engine::Engine;
 use crate::ui::{fetch_or_generate_thumbnail, paginate};
 use eframe::{egui, NativeOptions};
-use eframe::egui::{Context, DroppedFile, TextureHandle, Ui};
+use eframe::egui::{Context, DroppedFile, TextureHandle, Ui, UiKind};
 use rfd;
 use std::collections::HashMap;
 use std::path::Path;
@@ -66,17 +66,17 @@ pub fn search_panel(
 								if ui.button("Open").clicked() {
 									//let _ = std::process::Command::new("open").arg(&res.path).output();
 									open::that(&res.path);
-									ui.close_menu();
+									ui.close_kind(UiKind::Menu);
 								}
 								if ui.button("Open in View Tab").clicked() {
 									//let _ = std::process::Command::new("open").arg(&res.path).output();
 									app_state.selected_image = Some(res.clone());
 									app_state.active_tab = AppTab::View;
-									ui.close_menu();
+									ui.close_kind(UiKind::Menu);
 								}
 								if ui.button("Search for Similar").clicked() {
 									app_state.engine.as_mut().unwrap().query_by_image_hash_from_image(res);
-									ui.close_menu();
+									ui.close_kind(UiKind::Menu);
 								}
 							});
 
@@ -86,6 +86,17 @@ pub fn search_panel(
 								ui.label(format!("Similarity: {}", 1.0f64 / (1.0f64+res.distance_from_query.unwrap_or(1e10f64))));
 								ui.label(format!("Distance: {}", res.distance_from_query.unwrap_or(1e3f64)));
 								ui.label(format!("Size: {}x{}", res.resolution.0, res.resolution.1));
+
+								ui.horizontal(|ui|{
+									if ui.button("View").clicked() {
+										app_state.selected_image = Some(res.clone());
+										app_state.active_tab = AppTab::View;
+									}
+									if ui.button("Search for Similar").clicked() {
+										app_state.engine.as_mut().unwrap().query_by_image_hash_from_image(res);
+									}
+								});
+
 							});
 						});
 					});

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -8,7 +8,7 @@ pub fn settings_panel(
 ) {
 	ui.vertical(|ui|{
 		ui.checkbox(&mut app_state.dark_mode, "Dark Mode");
-		ui.add(egui::Slider::new(&mut app_state.search_text_min_length, 0..=255).text("Minimum Search Length")).on_hover_text("A search is automatically run when at least this many characters are entered into the search bar.  Be wary that 0 (match any letter) could slow down performance.");
+		ui.add(egui::Slider::new(&mut app_state.search_text_min_length, 0..=255).text("Minimum Search Length")).on_hover_text("A search is automatically run when at least this many characters are entered into the search bar.  0 disables automatic searching.  Small values may cause performance issues.");
 		ui.add(egui::Slider::new(&mut app_state.thumbnail_size, 0..=255).text("Thumbnail Size"));
 
 		if let Some(engine) = &mut app_state.engine {


### PR DESCRIPTION
Changes:
- Engine is indifferent to the spidering process and only gets a stream of images now.
- Instead of one DB connection protected by an Arc<Mutex> we're opening a read-only connection and a writer.
- Set write-ahead-logging pragma on SQLite when opening.